### PR TITLE
DeviceConnect iOS 2.2.10 対応

### DIFF
--- a/Specs/CocoaHTTPServer/2.3.1/CocoaHTTPServer.podspec.json
+++ b/Specs/CocoaHTTPServer/2.3.1/CocoaHTTPServer.podspec.json
@@ -1,0 +1,44 @@
+{
+  "name": "CocoaHTTPServer",
+  "version": "2.3.1",
+  "license": "BSD",
+  "summary": "A small, lightweight, embeddable HTTP server for Mac OS X or iOS applications.",
+  "homepage": "https://github.com/robbiehanson/CocoaHTTPServer",
+  "authors": {
+    "Robbie Hanson": "cocoahttpserver@googlegroups.com"
+  },
+  "source": {
+    "git": "https://github.com/robbiehanson/CocoaHTTPServer.git",
+    "branch": "master"
+  },
+  "source_files": "{Core,Extensions}/**/*.{h,m}",
+  "requires_arc": true,
+  "platforms": {
+    "ios": "5.0",
+    "osx": "10.7"
+  },
+  "ios": {
+    "frameworks": [
+      "CFNetwork",
+      "Security"
+    ]
+  },
+  "osx": {
+    "frameworks": [
+      "CoreServices",
+      "Security"
+    ]
+  },
+  "libraries": "xml2",
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"$(SDKROOT)/usr/include/libxml2\""
+  },
+  "dependencies": {
+    "CocoaAsyncSocket": [
+
+    ],
+    "CocoaLumberjack": [
+
+    ]
+  }
+}

--- a/Specs/DeviceConnectAWSIoT/2.2.10/DeviceConnectAWSIoTPlugin.podspec
+++ b/Specs/DeviceConnectAWSIoT/2.2.10/DeviceConnectAWSIoTPlugin.podspec
@@ -1,0 +1,44 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectAWSIoTPlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for AWSIoT"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for AWSIoT.
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDeviceAWSIoT"
+    
+    s.private_header_files = base_path + "/dConnectDeviceAWSIoT/Classes/**/*.h"
+    s.source_files = base_path + "/dConnectDeviceAWSIoT/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceAWSIoT_resources" => [base_path + "/dConnectDeviceAWSIoT/Resources/**/*.{#{common_resource_exts}}"]}
+    
+    s.dependency "DeviceConnectSDK"
+    s.dependency "AWSIoT"
+    
+end

--- a/Specs/DeviceConnectAllJoynPlugin/2.2.10/DeviceConnectAllJoynPlugin.podspec
+++ b/Specs/DeviceConnectAllJoynPlugin/2.2.10/DeviceConnectAllJoynPlugin.podspec
@@ -1,0 +1,53 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectAllJoynPlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for AllJoyn"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for AllJoyn.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    s.pod_target_xcconfig = {
+        # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+        # という旨で提供するライブラリがビルドされない問題への対処。
+        'ONLY_ACTIVE_ARCH' => 'NO',
+        'GCC_ENABLE_CPP_RTTI' => 'NO',
+        'GCC_PREPROCESSOR_DEFINITIONS' => "NS_BLOCK_ASSERTIONS=1 QCC_OS_GROUP_POSIX=1 QCC_OS_DARWIN=1"
+    }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDeviceAllJoyn"
+    
+    s.preserve_path = base_path + "/dConnectDeviceAllJoyn/Resources/AllJoynIntrospectionXML/*"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/dConnectDeviceAllJoyn/Supporting Files/dConnectDeviceAllJoyn-Prefix.pch"
+    s.private_header_files = base_path + "/dConnectDeviceAllJoyn/Sources/**/*.h", base_path + "/deps/AllJoynFramework/AllJoynFramework_iOS.h"
+    s.source_files = base_path + "/dConnectDeviceAllJoyn/Sources/**/*.{h,m,mm}", base_path + "/deps/AllJoynFramework/AllJoynFramework_iOS.h"
+    s.resource_bundles = {"dConnectDeviceAllJoyn_resources" => [base_path + "/dConnectDeviceAllJoyn/Resources/**/*.{#{common_resource_exts},jpg}"]}
+    
+    s.dependency "DeviceConnectSDK"
+    s.dependency "AllJoynCoreSDK", "15.04.00.b" # ./AllJoynCoreSDK.podspec を要公開
+    
+end

--- a/Specs/DeviceConnectChromecastPlugin/2.2.10/DeviceConnectChromecastPlugin.podspec
+++ b/Specs/DeviceConnectChromecastPlugin/2.2.10/DeviceConnectChromecastPlugin.podspec
@@ -1,0 +1,47 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectChromecastPlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for Chromecast"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for Chromecast.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDeviceChromeCast"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/dConnectDeviceChromecast/dConnectDeviceChromecast-Prefix.pch"
+    s.private_header_files = base_path + "/dConnectDeviceChromecast/Classes/**/*.h"
+    s.source_files = base_path + "/dConnectDeviceChromecast/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceChromecast_resources" => [base_path + "/dConnectDeviceChromecast/Resources/**/*.{#{common_resource_exts}}"]}
+    
+    s.dependency "DeviceConnectSDK"
+    s.vendored_frameworks = base_path + "/GoogleCastSDK-2.6.0-Release/GoogleCast.framework"
+    
+end

--- a/Specs/DeviceConnectHitoePlugin/2.2.10/DeviceConnectHitoePlugin.podspec
+++ b/Specs/DeviceConnectHitoePlugin/2.2.10/DeviceConnectHitoePlugin.podspec
@@ -1,0 +1,52 @@
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectHitoePlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for Hitoe"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for Hitoe.
+    
+    iOS simulator is not supported (Hitoe SDK does not have required architecture slices for building iOS simulator executable).
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+
+    }
+    
+    s.pod_target_xcconfig = {
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+        'ONLY_ACTIVE_ARCH' => 'NO',
+        'ENABLE_BITCODE' => 'NO'
+    }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+            base_path = "dConnectDevicePlugin/dConnectDeviceHitoe"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.public_header_files = base_path + "/dConnectDeviceHitoe/Headers/*.h"
+    s.source_files = base_path + "/dConnectDeviceHitoe/Headers/*.h", base_path + "/dConnectDeviceHitoe/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceHitoe_resources" => [base_path + "/dConnectDeviceHitoe/Resources/**/*.{#{common_resource_exts}}", base_path + "/RobotoUIKit.bundle"]}
+    
+    s.frameworks = "CoreGraphics", "CoreBluetooth", "CoreData"
+    s.dependency "DeviceConnectSDK"
+    s.dependency "DeviceConnectPluginSDK"
+    s.vendored_frameworks = base_path + "/hitoeAPI.framework"
+    
+end

--- a/Specs/DeviceConnectHostPlugin/2.2.10/DeviceConnectHostPlugin.podspec
+++ b/Specs/DeviceConnectHostPlugin/2.2.10/DeviceConnectHostPlugin.podspec
@@ -1,0 +1,46 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectHostPlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for Host"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for local iOS device.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDeviceHost"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/dConnectDeviceHost/DPHostDevicePlugin-Prefix.pch"
+    s.private_header_files = base_path + "/dConnectDeviceHost/Classes/**/*.h"
+    s.source_files = base_path + "/dConnectDeviceHost/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceHost_resources" => [base_path + "/dConnectDeviceHost_resources/**/*.{#{common_resource_exts}}"]}
+    
+    s.dependency "DeviceConnectSDK"
+    
+end

--- a/Specs/DeviceConnectHuePlugin/2.2.10/DeviceConnectHuePlugin.podspec
+++ b/Specs/DeviceConnectHuePlugin/2.2.10/DeviceConnectHuePlugin.podspec
@@ -1,0 +1,48 @@
+# TODO: Hue SDKはGithubで提供されているので、podspecで定義して取得するようにする。使用SDKの入手元とバージョン要チェック。
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectHuePlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for Hue"
+    
+    s.description  = <<-DESC
+    A Device Connect Plugin for Hue.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDeviceHue"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/dConnectDeviceHue/dConnectDeviceHue-Prefix.pch"
+    s.public_header_files = base_path + "/dConnectDeviceHue/Headers/*.h"
+    s.source_files = base_path + "/dConnectDeviceHue/Headers/*.h", base_path + "/dConnectDeviceHue/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceHue_resources" => [base_path + "/dConnectDeviceHue/Resources/**/*.{#{common_resource_exts}}"]}
+    
+    s.dependency "DeviceConnectSDK"
+    s.vendored_frameworks = base_path + "/HueSDK_iOS.framework"
+    
+end

--- a/Specs/DeviceConnectIRKitPlugin/2.2.10/DeviceConnectIRKitPlugin.podspec
+++ b/Specs/DeviceConnectIRKitPlugin/2.2.10/DeviceConnectIRKitPlugin.podspec
@@ -1,0 +1,47 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectIRKitPlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for IRKit"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for IRKit.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDeviceIRKit"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/dConnectDeviceIRKit/dConnectDeviceIRKit-Prefix.pch"
+    s.public_header_files = base_path + "/dConnectDeviceIRKit/Headers/*.h"
+    s.source_files = base_path + "/dConnectDeviceIRKit/Headers/*.h", base_path + "/dConnectDeviceIRKit/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceIRKit_resources" => [base_path + "/dConnectDeviceIRKit/Resources/**/*.{#{common_resource_exts}}"]}
+    
+    s.dependency "DeviceConnectSDK"
+    s.dependency "DeviceConnectPluginSDK"
+    
+end

--- a/Specs/DeviceConnectLinkingPlugin/2.2.10/DeviceConnectLinkingPlugin.podspec
+++ b/Specs/DeviceConnectLinkingPlugin/2.2.10/DeviceConnectLinkingPlugin.podspec
@@ -1,0 +1,46 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectLinkingPlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for Linking"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for Linking.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/TakayukiHoshi1984/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDeviceLinking"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/dConnectDeviceLinking/dConnectDeviceLinking-Prefix.pch"
+    s.public_header_files = base_path + "/dConnectDeviceLinking/Headers/*.h"
+    s.source_files = base_path + "/dConnectDeviceLinking/Headers/*.h", base_path + "/dConnectDeviceLinking/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceLinking_resources" => [base_path + "/dConnectDeviceLinking/Resources/**/*.{#{common_resource_exts}}"]}
+    
+    s.dependency "DeviceConnectSDK"
+    
+end

--- a/Specs/DeviceConnectPebblePlugin/2.2.10/DeviceConnectPebblePlugin.podspec
+++ b/Specs/DeviceConnectPebblePlugin/2.2.10/DeviceConnectPebblePlugin.podspec
@@ -1,0 +1,50 @@
+# TODO: Pebble SDKをCocoaPodsで導入できるようにできないか検討。使用SDKの入手元とバージョン要チェック。
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectPebblePlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Pugin for Pebble"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for Pebble device family.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDevicePebble"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/dConnectDevicePebble/dConnectDevicePebble-Prefix.pch"
+    s.private_header_files = base_path + "/dConnectDevicePebble/Classes/**/*.h"
+    s.source_files = base_path + "/dConnectDevicePebble/Headers/*.h", base_path + "/dConnectDevicePebble/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDevicePebble_resources" => [base_path + "/dConnectDevicePebble/Resources/**/*.{#{common_resource_exts},pbw}"]}
+
+    s.libraries = "z"
+    s.frameworks = "ExternalAccessory", "CoreMotion", "CoreBluetooth", "CFNetwork", "MessageUI"
+    s.dependency "DeviceConnectSDK"
+    s.vendored_frameworks = base_path + "/PebbleKit.framework", base_path + "/PebbleVendor.framework"
+    
+end

--- a/Specs/DeviceConnectPluginSDK/2.2.10/DeviceConnectPluginSDK.podspec
+++ b/Specs/DeviceConnectPluginSDK/2.2.10/DeviceConnectPluginSDK.podspec
@@ -1,0 +1,48 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectPluginSDK"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin SDK"
+    
+    s.description  = <<-DESC
+    Device Connect plugin SDK for iOS.
+    
+    This SDK defines Device Connect profiles that are in the incubation phase.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/DCMDevicePluginSDK"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/DCMDevicePluginSDK/DCMDevicePluginSDK-Prefix.pch"
+    s.header_dir = "DCMDevicePluginSDK"
+    s.public_header_files = base_path + "/DCMDevicePluginSDK/Headers/*.h"
+    s.source_files = base_path + "/DCMDevicePluginSDK/Headers/*.h", base_path + "/DCMDevicePluginSDK/Classes/**/*.{h,m}"
+    
+    s.dependency "DeviceConnectSDK"
+    
+end

--- a/Specs/DeviceConnectSDK/2.2.10/DeviceConnectSDK.podspec
+++ b/Specs/DeviceConnectSDK/2.2.10/DeviceConnectSDK.podspec
@@ -1,0 +1,54 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectSDK"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect SDK"
+    
+    s.description  = <<-DESC
+    Device Connect SDK for iOS.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectSDK/dConnectSDKForIOS"
+    
+    s.preserve_path = base_path + "/NOTICE.TXT"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/DConnectSDK/DConnectSDK-Prefix.pch"
+    s.header_dir = "DConnectSDK"
+    s.public_header_files = base_path + "/DConnectSDK/DConnectSDK/*.h"
+    s.source_files = base_path + "/DConnectSDK/DConnectSDK/*.h", base_path + "/DConnectSDK/Classes/**/*.{h,m,c}", base_path + "/DConnectSDK/Dependencies/GCIPUtil*.{h,m,c}", base_path + "/DConnectSDK/Dependencies/multipart-parser-c/*.{h,m,c}"
+    s.resource_bundles = {"DConnectSDK_resources" => [base_path + "/DConnectSDK/Resources/**/*.{#{common_resource_exts}}"]}
+
+    s.library = "sqlite3"
+ 
+    s.dependency 'CocoaAsyncSocket', '~> 7.6.1'
+    s.dependency 'CocoaHTTPServer', '~> 2.3.1'
+    s.dependency 'CocoaLumberjack', '~> 3.3.0'
+    s.dependency 'RoutingHTTPServer', '~> 1.0.0'
+ 
+end

--- a/Specs/DeviceConnectSonyCameraPlugin/2.2.10/DeviceConnectSonyCameraPlugin.podspec
+++ b/Specs/DeviceConnectSonyCameraPlugin/2.2.10/DeviceConnectSonyCameraPlugin.podspec
@@ -1,0 +1,46 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectSonyCameraPlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for Sony Camera"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for Sony Camera Remote API.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDeviceSonyCamera"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/dConnectDeviceSonyCamera/dConnectDeviceSonyCamera-Prefix.pch"
+    s.public_header_files = base_path + "/dConnectDeviceSonyCamera/Headers/*.h"
+    s.source_files = base_path + "/dConnectDeviceSonyCamera/Headers/*.h", base_path + "/dConnectDeviceSonyCamera/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceSonyCamera_resources" => [base_path + "/dConnectDeviceSonyCamera/Resources/**/*.{#{common_resource_exts}}"]}
+    
+    s.dependency "DeviceConnectSDK"
+    
+end

--- a/Specs/DeviceConnectSpheroPlugin/2.2.10/DeviceConnectSpheroPlugin.podspec
+++ b/Specs/DeviceConnectSpheroPlugin/2.2.10/DeviceConnectSpheroPlugin.podspec
@@ -1,0 +1,58 @@
+# TODO: RobotKitをCocoaPodsで導入できるようにできないか検討。使用SDKの入手元とバージョン要チェック。
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectSpheroPlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for Sphero"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for Sphero.
+    
+    iOS simulator is not supported (Sphero SDK does not have required architecture slices for building iOS simulator executable).
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    s.pod_target_xcconfig = {
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+        'ONLY_ACTIVE_ARCH' => 'NO',
+        'ENABLE_BITCODE' => 'NO'
+    }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+            base_path = "dConnectDevicePlugin/dConnectDeviceSphero"
+    
+    # エンドターゲット（アプリとか）のプリコンパイルドヘッダー汚染の恐れあり。
+    s.prefix_header_file = base_path + "/dConnectDeviceSphero/dConnectDeviceSphero-Prefix.pch"
+    s.public_header_files = base_path + "/dConnectDeviceSphero/Headers/*.h"
+    s.source_files = base_path + "/dConnectDeviceSphero/Headers/*.h", base_path + "/dConnectDeviceSphero/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceSphero_resources" => [base_path + "/dConnectDeviceSphero/Resources/**/*.{#{common_resource_exts}}", base_path + "/RobotoUIKit.bundle"]}
+    
+    # libstdc++.dylibだけでOKなはずなのだが、stdc++.6.dylibやstdc++.6.0.9.dylib
+    # などでないとGNU C++関連のシンボル解決に失敗するので、その対処。
+    s.libraries = "stdc++", "stdc++.6"
+    s.frameworks = "ExternalAccessory", "CoreMotion"
+    s.dependency "DeviceConnectSDK"
+    s.dependency "DeviceConnectPluginSDK"
+    s.vendored_frameworks = base_path + "/RobotKit.framework", base_path + "/RobotUIKit.framework"
+    
+end

--- a/Specs/DeviceConnectThetaPlugin/2.2.10/DeviceConnectThetaPlugin.podspec
+++ b/Specs/DeviceConnectThetaPlugin/2.2.10/DeviceConnectThetaPlugin.podspec
@@ -1,0 +1,53 @@
+# TODO: plistの変数展開はどうすれば良いだろうか。
+Pod::Spec.new do |s|
+    
+    s.name         = "DeviceConnectThetaPlugin"
+    s.version      = "2.2.10"
+    s.summary      = "Device Connect Plugin for Ricoh THETA"
+    
+    s.description  = <<-DESC
+    A Device Connect plugin for Ricoh THETA device family.
+    
+    You need to sign up and download RICOH THETA SDK at the developer center: https://developers.theta360.com/en/docs/sdk/download.html .
+    Also, path to the SDK zip file must be set to environment variable DC_THETA_SDK_ZIP_PATH when installing or updating this Pod.
+    
+    Device Connect is an IoT solution for interconnecting various modern devices.
+    Also available in Android: https://github.com/DeviceConnect/DeviceConnect-Android .
+    DESC
+    
+    s.homepage     = "https://github.com/DeviceConnect/DeviceConnect-iOS"
+    # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+    
+    s.license      = {:type => "MIT", :file => "LICENSE.TXT"}
+    
+    s.author       = "NTT DOCOMO, INC."
+    # s.authors            = { "NTT DOCOMO, INC." => "*****@*****" }
+    # s.social_media_url   = "https://www.facebook.com/docomo.official"
+    
+    # プロパティのweak属性と、automatic property synthesisをサポートするために6.0以降が必要。
+    s.platform     = :ios, "9.0"
+    
+    s.source       = {
+        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
+    }
+    
+    # エンドターゲット（アプリとか）のDebugビルドの際、対応するアーキテクチャが含まれていない
+    # という旨で提供するライブラリがビルドされない問題への対処。
+    s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'NO' }
+    
+    common_resource_exts = "plist,lproj,storyboard,strings,xcdatamodeld,png"
+    base_path = "dConnectDevicePlugin/dConnectDeviceTheta"
+    
+    # RICOH THETA SDK for iOS v0.3.0のZipへのパスを指定してもらう。
+    s.prepare_command = <<-CMD
+    cd #{base_path}
+    ruby require_theta_sdk.rb
+    CMD
+    
+    s.public_header_files = base_path + "/dConnectDeviceTheta/Headers/*.h"
+    s.source_files = base_path + "/dConnectDeviceTheta/Headers/*.h", base_path + "/dConnectDeviceTheta/Classes/**/*.{h,m}"
+    s.resource_bundles = {"dConnectDeviceTheta_resources" => [base_path + "/dConnectDeviceTheta/Resources/**/*.{#{common_resource_exts}}"]}
+    
+    s.dependency "DeviceConnectSDK"
+    
+end


### PR DESCRIPTION
DeviceConnect-iOS の podspecを 2.2.10 に対応させました。問題がないようでしたらマージいただけると助かります。

以下、対応の詳細です。

## 各プラグインの podspec
各プラグインの podspecは 2.1.0 のpodspecをコピーして作成しています。その際、sourceの指定を以下のようにタグ指定に変更いたしました。

```
    s.source       = {
        :git => "https://github.com/DeviceConnect/DeviceConnect-iOS", :tag => "v2.2.10-release-20171228"
    }
```

2.1.0のpodspecではここが `:branch => "master"` とブランチ名で指定されていたため、チェックアウトするタイミングによって異なるソースコードが取得できてしまう問題があります。例えば、今 2.1.0をチェックアウトすると 2.2.10よりさらに新しい開発中のソースコードがチェックアウトされてしまいます。
（2.0.0および 2.1.0の podspecについても別途修正すべきと思いますが、今回のプルリクエストには含めていません）

そこで、今回追加した 2.2.10 のpodspecについては上記の通りタグで指定するようにし、そのような問題が起こらないようになっています。

なお、CocoaPods は `~/Library/Caches/CocoaPods/` 以下にキャッシュを持っているため、`pod update`しても過去にチェックアウトされたものがそのまま使われてしまうため、ローカルで試される場合はキャッシュを削除してから行なってください。
(CocoaPodsは podspecの SHA-1 ハッシュ値をキーにしてキャッシュしているため、podspec自体に変更が無いとキャッシュを破棄してくれません。そのため、ソースコードのブランチが進んでも、新しいコミットがチェックアウトされることはありません)

## DeviceConnect SDK の podspec

プラグイン同様、こちらもタグでバージョンを固定するようにしています。
また、SDKが依存する外部ライブラリを、以下のように CocoaPods の依存で解決するように修正いたしました。

```
    s.dependency 'CocoaAsyncSocket', '~> 7.6.1'
    s.dependency 'CocoaHTTPServer', '~> 2.3.1'
    s.dependency 'CocoaLumberjack', '~> 3.3.0'
    s.dependency 'RoutingHTTPServer', '~> 1.0.0'
 ```

これにより、上記モジュールについては /DConnectSDK/Dependencies/　以下にあるソースコードは使用しないため、`s.source_files`でそれらが取り込まれないように工夫しています。

## CocoaHTTPServer 2.3.1について

DeviceConnect SDK の Dependencies 以下に取り込まれている CocoaHTTPServerは、 https://github.com/robbiehanson/CocoaHTTPServer の最終コミット (
Latest commit 52b2a64  on 5 Jan 2015) だと思われますが、こちらのコミットに相当する podspec が本家CocoaPodsのリポジトリに存在しません。

そのため、CocoaHTTPServer の最終バージョンに 0.0.1 を足した 2.3.1 というバージョンの podspecを本リポジトリに追加し、DeviceConnect SDK からはそちらを参照するようにしています。

## 利用例

今回の 2.2.10のpodspecは https://github.com/kunichiko/DeviceConnect-PodSpecs にフォークして公開しております。

また、以下のプロジェクトで実際にこれらの podspecを利用しておりますので、参考にしてください。
https://github.com/EXILIM-Plugin/EXILIM-Plugin-iOS-ControllerApp